### PR TITLE
docs: refactor skills, MCP, and agent-gateway docs for v0.2.0

### DIFF
--- a/content/docs/agents/mcp-servers.md
+++ b/content/docs/agents/mcp-servers.md
@@ -8,7 +8,21 @@ order: 2
 
 The Model Context Protocol (MCP) is an open standard for connecting AI agents to external tools and data sources. MCP servers expose capabilities (tools, resources, prompts) over a standardized JSON-RPC transport. Agents that support MCP can discover and invoke these capabilities at runtime.
 
-In Nanosandbox, MCP servers run inside the sandbox alongside the agent, providing secure access to tools without exposing the host system.
+In Nanosandbox, the agent-gateway manages MCP server configuration inside the sandbox. It generates the correct config format for each agent type so servers work consistently across Claude, Goose, Codex, and Cursor.
+
+## Config vs Commands
+
+> **sandbox.yml** and **TUI commands** are two ways to manage MCP servers. They behave differently:
+>
+> | | `sandbox.yml` | TUI `/mcp add` |
+> |---|---|---|
+> | **When applied** | Every time the sandbox starts (bootstrap) | Immediately, once |
+> | **Source tag** | `config` | `runtime` |
+> | **On sandbox restart** | Re-applied from config (always fresh) | Preserved — survives restarts |
+> | **On sandbox.yml change** | Old config servers replaced with new ones | Untouched — runtime servers kept |
+> | **Persisted where** | In your `sandbox.yml` file | In `~/.nanosandbox/state.json` inside the VM |
+>
+> **In short:** `sandbox.yml` is your declarative baseline. TUI commands are for ad-hoc additions that persist alongside the config without interfering with it. If a config server and a runtime server share the same name, the config version wins on next bootstrap.
 
 ## Configuring MCP Servers
 
@@ -19,6 +33,7 @@ MCP servers are configured in the `mcp` section of `sandbox.yml`. Each entry is 
 sandboxes:
   claude:
     image: claude
+    type: claude
     env:
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
     mcp:
@@ -41,7 +56,7 @@ Each named MCP server entry supports:
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `command` | `string` | Yes | The executable to run |
+| `command` | `string` | Yes | The executable to run (`npx`, `uvx`, or a binary) |
 | `args` | `string[]` | No | Arguments passed to the command |
 | `env` | `map` | No | Additional environment variables for this server |
 | `enabled` | `boolean` | No | Whether this server is enabled (default: `true`) |
@@ -68,7 +83,7 @@ sandboxes:
         args: ["-y", "@modelcontextprotocol/server-github"]
 ```
 
-In this example, the `claude` sandbox gets both the `memory` server (from defaults) and the `github` server (from its own config). If a sandbox defines a server with the same name as a default, the sandbox version takes precedence.
+In this example, the `claude` sandbox gets both the `memory` server (from defaults) and the `github` server (from its own config). If both define a server with the same name, the sandbox version takes precedence.
 
 ### Variable Substitution
 
@@ -156,27 +171,27 @@ mcp:
 
 **Exposed tools**: `query` (read-only SQL execution).
 
-## Agent-Gateway Integration
+## How MCP Config Is Generated
 
-When Nanosandbox launches an agent with MCP servers configured, it:
+The agent-gateway generates the correct MCP config format for each agent type. Each agent reads MCP config from a different location and in a different format:
 
-1. Starts each MCP server process inside the sandbox.
-2. Waits for each server to emit its capabilities on stdout (JSON-RPC initialization).
-3. Configures the agent's MCP client to connect to the running servers via stdio transport.
-4. The agent can then discover and invoke tools from all configured servers.
+| Agent | Config Format | Config Location |
+|---|---|---|
+| Claude Code | JSON (`mcpServers` in settings) | `~/.claude.json` |
+| Goose | YAML (`extensions:` with `cmd:`/`envs:`) | `~/.config/goose/config.yaml` |
+| Codex | TOML (`[mcp_servers.<name>]`) | `~/.codex/config.toml` |
+| Cursor | JSON (`mcpServers` in settings) | `~/.cursor/mcp.json` |
+
+### Cross-Agent Compatibility
+
+MCP servers defined with `npx` commands automatically get `uvx` equivalents generated for agents that use Python tooling (Goose). The gateway handles this transparently — you define the server once and it works across all agents.
 
 ```
-+-------------------------------------------------------+
-|                     Sandbox VM                         |
-|                                                        |
-|  +--------+    stdio    +-------------------+          |
-|  | Agent  | <---------> | MCP Server (GitHub)|         |
-|  |        |    stdio    +-------------------+          |
-|  |        | <---------> | MCP Server (Memory)|         |
-|  |        |    stdio    +-------------------+          |
-|  |        | <---------> | MCP Server (FS)    |         |
-|  +--------+             +-------------------+          |
-+-------------------------------------------------------+
+sandbox.yml:  command: npx, args: ["-y", "@modelcontextprotocol/server-github"]
+    ├── Claude:  npx -y @modelcontextprotocol/server-github
+    ├── Codex:   npx -y @modelcontextprotocol/server-github
+    ├── Cursor:  npx -y @modelcontextprotocol/server-github
+    └── Goose:   uvx mcp-server-github  (auto-generated override)
 ```
 
 ## Managing MCP in TUI
@@ -184,13 +199,34 @@ When Nanosandbox launches an agent with MCP servers configured, it:
 The TUI provides slash commands for managing MCP servers interactively:
 
 ```
-/mcp              Toggle the MCP sidebar
-/mcp list         List configured MCP servers
-/mcp add <name>   Add an MCP server
-/mcp remove <name> Remove an MCP server
-/mcp enable <name> Enable a disabled MCP server
-/mcp disable <name> Disable an MCP server
+/mcp                                      Toggle the MCP sidebar
+/mcp list                                 List configured MCP servers
+/mcp add <name> <command> [args...]       Add an MCP server to the focused sandbox
+/mcp add --all <name> <command> [args...] Add an MCP server to all sandboxes
+/mcp add --sandbox <name> <server> ...    Add an MCP server to a specific sandbox
+/mcp remove <name>                        Remove an MCP server
+/mcp remove --all <name>                  Remove from all sandboxes
+/mcp enable <name>                        Enable a disabled MCP server
+/mcp disable <name>                       Disable an MCP server
 ```
+
+### Example: Adding an MCP Server via TUI
+
+```
+/mcp add memory npx -y @modelcontextprotocol/server-memory
+# Added MCP server: memory
+
+/mcp add --all github npx -y @modelcontextprotocol/server-github
+# Added MCP server 'github' to all sandboxes
+```
+
+MCP servers added via TUI are tagged as **runtime-sourced** and persist across sandbox restarts, even if they are not in `sandbox.yml`.
+
+After adding or removing an MCP server, the TUI prompts you to reconnect (`/reconnect`) so the agent picks up the updated MCP configuration.
+
+## State Persistence
+
+MCP server definitions (along with skills) are persisted to `~/.nanosandbox/state.json` inside the VM. This file is saved on every mutation and reloaded on startup. The `~/.nanosandbox/` directory is symlinked to `/workspace/.nanosb-state/.nanosandbox/`, so it survives VM restarts via virtio-fs.
 
 ## Troubleshooting
 

--- a/content/docs/agents/overview.md
+++ b/content/docs/agents/overview.md
@@ -8,23 +8,48 @@ order: 1
 
 Nanosandbox provides pre-built, sandboxed environments for popular AI coding agents. Each agent runs inside its own lightweight VM with full filesystem and network isolation.
 
-| Agent | CLI Name | Image | Size |
+| Agent | CLI Name | Image | Agent Type |
 |---|---|---|---|
-| Claude Code | `claude` | `ghcr.io/nanosandboxai/agents-registry/claude:latest` | ~190MB |
-| Goose | `goose` | `ghcr.io/nanosandboxai/agents-registry/goose:latest` | ~185MB |
-| Codex | `codex` | `ghcr.io/nanosandboxai/agents-registry/codex:latest` | ~195MB |
-| Cursor | `cursor` | `ghcr.io/nanosandboxai/agents-registry/cursor:latest` | ~200MB |
+| Claude Code | `claude` | `ghcr.io/nanosandboxai/agents-registry/claude:latest` | `claude` |
+| Goose | `goose` | `ghcr.io/nanosandboxai/agents-registry/goose:latest` | `goose` |
+| Codex | `codex` | `ghcr.io/nanosandboxai/agents-registry/codex:latest` | `codex` |
+| Cursor | `cursor` | `ghcr.io/nanosandboxai/agents-registry/cursor:latest` | `cursor` |
 
 ## Base Image
 
 All agent images are built on a common base:
 
-- **OS**: Alpine 3.20
-- **Runtime**: Node.js 22 (LTS)
-- **Base size**: ~150MB
+- **OS**: Debian (node:22-slim)
+- **Runtime**: Node.js 22 (LTS), Python 3 + uv/uvx
+- **Included tools**: git, curl, bash, sudo, openssh (dropbear)
 - **Registry**: `ghcr.io/nanosandboxai/agents-registry/`
 
-The base image includes common development tools: git, curl, openssh-client, and a POSIX shell.
+The base image includes the **agent-gateway** binary — an HTTP server (`:8080`) that manages skill files, MCP config generation, and state persistence inside the VM.
+
+## Architecture
+
+Each sandbox VM runs:
+
+```
++-----------------------------------------------------------+
+|                       Sandbox VM                          |
+|                                                           |
+|  nanosb-init.sh (PID 1)                                  |
+|    ├── agent-gateway :8080  (skills, MCP, state mgmt)    |
+|    ├── dropbear sshd :2222  (terminal access)            |
+|    └── agent process        (claude, goose, codex, etc.) |
+|                                                           |
+|  /workspace/          ← project mounted via virtio-fs    |
+|  /home/developer/     ← agent HOME (symlinked to state)  |
+|  .nanosb-state/       ← persisted state directory        |
++-----------------------------------------------------------+
+```
+
+The **agent-gateway** is the bridge between the CLI and the agent. It:
+- Receives skill and MCP definitions from the CLI via bootstrap
+- Generates agent-specific config files (each agent reads a different format)
+- Persists state to `~/.nanosandbox/state.json` so skills/MCPs survive VM restarts
+- Serves a REST API for runtime skill/MCP management from the TUI
 
 ## Pulling Agent Images
 
@@ -55,6 +80,10 @@ defaults:
 sandboxes:
   claude:
     image: claude
+    type: claude
+    skills:
+      - git-workflow
+      - tdd
     env:
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
     mcp:
@@ -135,7 +164,7 @@ Agents can share context through several mechanisms.
 
 ### Project Mount
 
-All agents mount the project directory at `/workspace` via virtio-fs. Use the `--project` flag to specify which directory to mount:
+All agents mount the project directory at `/workspace` via virtio-fs. This is the fixed mount point for all sandboxes. Use the `--project` flag to specify which directory to mount:
 
 ```bash
 nanosb run --project ./my-project claude

--- a/content/docs/agents/skills.md
+++ b/content/docs/agents/skills.md
@@ -20,6 +20,9 @@ name: git-workflow
 description: Git workflow best practices with conventional commits and clean history
 version: "1.0"
 tags: [git, workflow, collaboration]
+when_to_use: Use when working with git, creating commits, managing branches, or opening PRs
+allowed_tools: [Bash]
+user_invocable: true
 ---
 
 ## Commit Messages
@@ -39,6 +42,10 @@ Follow trunk-based development...
 | `description` | `string` | Yes | Human-readable description |
 | `version` | `string` | No | Semantic version |
 | `tags` | `string[]` | No | Keywords for categorization and discovery |
+| `when_to_use` | `string` | No | Hint for when the agent should auto-invoke this skill |
+| `allowed_tools` | `string[]` | No | Tools pre-approved for this skill (Claude-specific) |
+| `user_invocable` | `boolean` | No | Whether the skill appears in `/skills` menu (default: `true`) |
+| `paths` | `string[]` | No | Glob patterns — skill auto-attaches when matching files are in context |
 
 The markdown body contains the actual guidance content that gets injected into the agent's context.
 
@@ -56,6 +63,20 @@ Skills are available from two sources: the **public registry** (community-mainta
 | `documentation` | Documentation writing guidelines | docs, writing |
 | `security-best-practices` | Security-focused development practices | security, best-practices |
 
+## Config vs Commands
+
+> **sandbox.yml** and **TUI commands** are two ways to manage skills. They behave differently:
+>
+> | | `sandbox.yml` | TUI `/skills add` |
+> |---|---|---|
+> | **When applied** | Every time the sandbox starts (bootstrap) | Immediately, once |
+> | **Source tag** | `config` | `runtime` |
+> | **On sandbox restart** | Re-applied from config (always fresh) | Preserved — survives restarts |
+> | **On sandbox.yml change** | Old config skills replaced with new ones | Untouched — runtime skills kept |
+> | **Persisted where** | In your `sandbox.yml` file | In `~/.nanosandbox/state.json` inside the VM |
+>
+> **In short:** `sandbox.yml` is your declarative baseline. TUI commands are for ad-hoc additions that persist alongside the config without interfering with it. If a config skill and a runtime skill share the same name, the config version wins on next bootstrap.
+
 ## Configuring Skills in sandbox.yml
 
 Skills can be pre-configured in `sandbox.yml` so they load automatically when a sandbox starts:
@@ -70,6 +91,7 @@ defaults:
 sandboxes:
   claude:
     image: claude
+    type: claude
     skills:
       - git-workflow
       - code-review
@@ -80,15 +102,20 @@ sandboxes:
 
 Per-sandbox skills **replace** defaults skills (they are not merged). In this example, the `claude` sandbox gets `git-workflow`, `code-review`, and `security-best-practices` — not `tdd` from defaults.
 
+Skills defined in `sandbox.yml` are tagged as **config-sourced**. They are re-applied on every bootstrap (sandbox restart).
+
 ## Using Skills in TUI
 
 The TUI provides slash commands for managing skills interactively:
 
 ```
-/skills list          List all available skills
-/skills add <name>    Add a skill to the current sandbox
-/skills remove <name> Remove a skill from the current sandbox
-/skills show <name>   Show the content of a skill
+/skills list                              List all available skills
+/skills add <name>                        Add a skill to the focused sandbox
+/skills add --all <name>                  Add a skill to all sandboxes
+/skills add --sandbox <name> <skill>      Add a skill to a specific sandbox
+/skills remove <name>                     Remove a skill from the focused sandbox
+/skills remove --all <name>               Remove a skill from all sandboxes
+/skills show <name>                       Show the content of a skill
 ```
 
 ### Example Session
@@ -108,8 +135,8 @@ $ nanosb
 /skills add git-workflow
 # Added skill: git-workflow
 
-/skills add tdd
-# Added skill: tdd
+/skills add --all tdd
+# Added skill 'tdd' to all sandboxes
 
 /skills show git-workflow
 # (displays the full markdown content of the skill)
@@ -117,13 +144,43 @@ $ nanosb
 
 ## How Skills Work
 
-When a skill is added to a sandbox:
+When a skill is added to a sandbox, the agent-gateway generates agent-specific config files. Each agent reads skills in a different format:
 
-1. The skill's markdown content is loaded from the registry.
-2. The content is injected into the agent's system context.
-3. The agent follows the guidance defined in the skill while performing tasks.
+| Agent | Skill Format | Location |
+|---|---|---|
+| Claude Code | Individual `SKILL.md` files with YAML frontmatter | `~/.claude/skills/<name>/SKILL.md` |
+| Cursor | Individual `.mdc` rule files with frontmatter | `~/.cursor/rules/nanosb-<name>.mdc` |
+| Goose | All skills concatenated into a single hints file | `~/.config/goose/.goosehints` |
+| Codex | Individual `SKILL.md` files | `~/.agents/skills/<name>/SKILL.md` |
 
-Skills are lightweight — they add context, not dependencies. They don't install packages or modify the filesystem. The agent simply receives the skill's instructions as part of its prompt context.
+The gateway writes these files to the agent's HOME directory (not `/workspace/`), so they never appear in the user's git tree. These HOME paths are symlinked to `/workspace/.nanosb-state/` by the init script, which means they persist across VM restarts via virtio-fs.
+
+The `.nanosb-state/` directory is automatically excluded from git tracking via `.git/info/exclude`, so it never shows up in `git status` or gets accidentally committed.
+
+### Two-Layer Config Model
+
+Nanosandbox uses a two-layer approach for agent configuration:
+
+**Layer 1 — Gateway-managed (HOME paths):**
+Files generated by the agent-gateway (skill files, MCP configs, prompt files). Written to HOME directories like `~/.claude/`, `~/.codex/`, etc. Persisted via `.nanosb-state/` symlinks. Never pollute the user's git tree.
+
+**Layer 2 — User-owned (project files):**
+Files the user places in `/workspace/` themselves (e.g., `CLAUDE.md`, `.cursor/rules/`). These are read by agents natively alongside Layer 1. The gateway does not touch these.
+
+Both layers are read by the agent — they complement each other.
+
+## Source Tracking: Config vs Runtime
+
+Skills have a **source** that determines their lifecycle:
+
+| Source | Origin | Survives bootstrap? |
+|---|---|---|
+| `config` | Defined in `sandbox.yml` | Replaced with fresh version on every bootstrap |
+| `runtime` | Added via TUI (`/skills add`) | Preserved across bootstrap cycles |
+
+When you modify `sandbox.yml` and restart, config-sourced skills are refreshed from the new config, but runtime-added skills (from TUI) are preserved. This means you can add skills interactively without losing them on restart.
+
+State is persisted to `~/.nanosandbox/state.json` inside the VM, which survives VM restarts via the `.nanosb-state/` symlink mechanism.
 
 ## Skill Sources
 

--- a/content/docs/cli/configuration.md
+++ b/content/docs/cli/configuration.md
@@ -15,7 +15,6 @@ defaults:
   cpus: 2
   memory: 4096
   timeout: 600
-  workdir: /workspace
   skills:
     - git-workflow
     - tdd
@@ -64,7 +63,6 @@ The `defaults` section sets baseline values applied to every sandbox unless over
 | `cpus` | integer | CPU cores allocated (runtime default: 1) |
 | `memory` | integer | Memory in MB (runtime default: 512) |
 | `timeout` | integer | Maximum runtime in seconds (runtime default: 300) |
-| `workdir` | string | Working directory inside the sandbox (default: `/workspace`) |
 | `env` | map | Environment variables injected into every sandbox |
 | `env_file` | string | Path to a file containing `KEY=VALUE` environment variables |
 | `network` | object | Network configuration (see [network](#network)) |
@@ -94,7 +92,6 @@ sandboxes:
     cpus: <n>
     memory: <mb>
     timeout: <secs>
-    workdir: <path>
     agent: <agent-name>
     skills: [<skill>, ...]
     auto_mode: <bool>

--- a/content/docs/cli/tui-mode.md
+++ b/content/docs/cli/tui-mode.md
@@ -83,8 +83,11 @@ The `/add` command supports these options:
 |---|---|
 | `/mcp` | Toggle the MCP sidebar |
 | `/mcp list` | List configured MCP servers |
-| `/mcp add <name> <command> [args...]` | Add an MCP server |
-| `/mcp remove <name>` | Remove an MCP server |
+| `/mcp add <name> <command> [args...]` | Add an MCP server to the focused sandbox |
+| `/mcp add --all <name> <command> [args...]` | Add an MCP server to all sandboxes |
+| `/mcp add --sandbox <name> <server> <cmd> [args...]` | Add to a specific sandbox |
+| `/mcp remove <name>` | Remove an MCP server from the focused sandbox |
+| `/mcp remove --all <name>` | Remove from all sandboxes |
 | `/mcp enable <name>` | Enable a disabled MCP server |
 | `/mcp disable <name>` | Disable an MCP server |
 
@@ -94,8 +97,11 @@ The `/add` command supports these options:
 |---|---|
 | `/skills` | Toggle the skills sidebar |
 | `/skills list` | List available skills |
-| `/skills add <name>` | Add a skill to the sandbox |
-| `/skills remove <name>` | Remove a skill from the sandbox |
+| `/skills add <name>` | Add a skill to the focused sandbox |
+| `/skills add --all <name>` | Add a skill to all sandboxes |
+| `/skills add --sandbox <name> <skill>` | Add to a specific sandbox |
+| `/skills remove <name>` | Remove a skill from the focused sandbox |
+| `/skills remove --all <name>` | Remove from all sandboxes |
 | `/skills show <name>` | Show the content of a skill |
 
 ### Git & Files


### PR DESCRIPTION
## Summary
- Fix base image info (Alpine → Debian, add Python 3 + uv/uvx)
- Remove `workdir` from configuration reference (removed in v0.2.0)
- Add enriched skill frontmatter fields (`when_to_use`, `allowed_tools`, `user_invocable`, `paths`)
- Add **Config vs Commands** info boxes explaining source tracking (`config` vs `runtime`)
- Document per-agent skill formats (SKILL.md, .mdc, .goosehints, AGENTS.md)
- Document per-agent MCP config formats and cross-agent compatibility (npx↔uvx)
- Add two-layer config model (gateway-managed HOME paths vs user-owned /workspace)
- Add `--all` and `--sandbox <name>` targeting to TUI skill/MCP commands
- Document state persistence (`~/.nanosandbox/state.json`) and `.nanosb-state/` symlinks
- Add architecture diagram showing agent-gateway role in the VM
- Document agent restart prompt after MCP changes

## Related PRs
- nanosandboxai/agents-registry#9
- nanosandboxai/sandbox#9
- nanosandboxai/cli#39