### PR TITLE
docs(windows): add install, requirements, troubleshooting, and architecture docs

### DIFF
--- a/content/docs/architecture/_meta.json
+++ b/content/docs/architecture/_meta.json
@@ -1,0 +1,1 @@
+{ "label": "Architecture", "order": 25 }

--- a/content/docs/architecture/overview.md
+++ b/content/docs/architecture/overview.md
@@ -24,9 +24,11 @@ Your project directory is mounted into the sandbox so the agent can read and edi
 
 | Platform | Workspace mount | Permissions behavior | Extended attributes | Directory listings |
 | --- | --- | --- | --- | --- |
-| macOS | virtio-fs | POSIX-style | Supported | Stable |
-| Linux | virtio-fs | POSIX-style | Supported | Stable |
-| Windows | virtio-fs on NTFS | Linux-like behavior for common workflows | Supported with limits | Stable for day-to-day use |
+| macOS | virtio-fs (direct) | POSIX-style | Supported | Stable |
+| Linux | virtio-fs (direct) | POSIX-style | Supported | Stable |
+| Windows | FUSE-on-vsock backed by NTFS | Linux-like behavior for common workflows | Supported with limits | Stable for day-to-day use |
+
+On Windows, the host runs a small FUSE server that talks to the guest over an AF_VSOCK socket. The guest mounts that socket as a `fuse.virtiofs`-compatible filesystem, so agents see the same `/workspace/` layout as on macOS or Linux. The four runtime files (`libkrunfw.dll`, `busybox`, `vsock_proxy`, `fuse_mount`) carry this bridge — see [installation](/docs/getting-started/installation) for details.
 
 For most users, this means package installs, builds, tests, and normal project cleanup work the same way across platforms.
 

--- a/content/docs/architecture/overview.md
+++ b/content/docs/architecture/overview.md
@@ -1,0 +1,47 @@
+---
+title: "Architecture Overview"
+description: "How nanosb builds a sandbox across macOS, Linux, and Windows"
+order: 1
+---
+
+## How a Sandbox Is Built
+
+Nanosandbox uses the same high-level flow on every host OS. The CLI starts a microVM through `libkrun`, the platform hypervisor provides hardware isolation, and a Linux guest kernel runs the workload.
+
+```mermaid
+graph LR
+    A["nanosb CLI"] --> B["libkrun"]
+    B --> C["Host hypervisor\n(HVF / KVM / WHPX)"]
+    C --> D["Isolated microVM\nLinux guest kernel"]
+    D --> E["Agent runtime + project workspace"]
+```
+
+This keeps the isolation boundary consistent while still using each platform's native virtualization backend.
+
+## Workspace Sharing Across Platforms
+
+Your project directory is mounted into the sandbox so the agent can read and edit files directly.
+
+| Platform | Workspace mount | Permissions behavior | Extended attributes | Directory listings |
+| --- | --- | --- | --- | --- |
+| macOS | virtio-fs | POSIX-style | Supported | Stable |
+| Linux | virtio-fs | POSIX-style | Supported | Stable |
+| Windows | virtio-fs on NTFS | Linux-like behavior for common workflows | Supported with limits | Stable for day-to-day use |
+
+For most users, this means package installs, builds, tests, and normal project cleanup work the same way across platforms.
+
+## What Is Still Being Tightened on Windows
+
+Windows support is live and practical, but a few advanced edge cases are still being improved:
+
+- Cross-process file locking behaviors in rare tool combinations.
+- A small set of low-level read/write hints that only advanced workloads use.
+- Some shared-memory mapping patterns used by highly specialized tools.
+
+These do not affect the common local development loop. If you hit one of these cases, start with the troubleshooting guides and share a reproducible example so we can prioritize it.
+
+## Related Reading
+
+- [Linux Is Hardened. Windows Is Live. The Sandbox Runs Everywhere.](/articles/docker-sbx-linux-windows-shipped)
+- [How We See Sandboxing Today](/articles/how-we-see-sandboxing-today)
+- [Troubleshooting: Common Errors](/docs/troubleshooting/common-errors)

--- a/content/docs/cli/commands.md
+++ b/content/docs/cli/commands.md
@@ -68,6 +68,7 @@ Creates a sandbox from the specified image and executes `cmd`. If `cmd` is omitt
 | `--timeout <secs>` | Maximum runtime in seconds (default: 600) |
 | `-e KEY=VALUE` | Inject environment variable (repeatable) |
 | `--env-file <path>` | Load env vars from file (single file; use the global `--env-file` flag for multiple files) |
+| `--run-as-root` | Run the agent command as root inside the guest (default: non-root user) |
 | `--buffered` | Buffer output instead of streaming (useful with `--format json`) |
 
 **Examples:**
@@ -84,7 +85,12 @@ nanosb run --cpus 4 --memory 8192 -e ANTHROPIC_API_KEY=sk-... claude
 
 # Name the sandbox
 nanosb run --name my-claude claude
+
+# Run as root inside the guest (Windows FUSE workspace, system package installs, etc.)
+nanosb run --run-as-root claude "apt-get install -y graphviz"
 ```
+
+> **About `--run-as-root`.** By default the agent runs as a non-root user inside the guest (typically `uid 1000`) because some agents — for example Claude Code — refuse to start as root. `--run-as-root` overrides that. It is most often useful on Windows, where the FUSE workspace is backed by NTFS and a few system-level package or build workflows need root in the guest to write outside the user-owned tree. Keep the default off unless a specific workflow requires it.
 
 ## nanosb exec
 

--- a/content/docs/cli/tui-mode.md
+++ b/content/docs/cli/tui-mode.md
@@ -66,7 +66,24 @@ The `/add` command supports these options:
 /add claude --model claude-sonnet-4-5-20250929  # Specify model
 /add claude --name my-sandbox        # Custom sandbox name
 /add claude --auto-mode -p "Fix tests"  # Headless autonomous mode
+/add claude --run-as-root            # Run the agent as root inside the guest
 ```
+
+Full option list:
+
+| Option | Description |
+|---|---|
+| `--tag <version>` | Pin a specific image tag |
+| `--model <model>` | Override the default model for the agent |
+| `--image <ref>` | Use a custom image reference instead of the agent default |
+| `--project <path>` | Mount a host directory as the workspace |
+| `--branch <name>` | Check out a git branch before starting |
+| `--name <name>` | Use a custom sandbox name |
+| `--auto-mode -p "<prompt>"` | Headless autonomous mode with the given prompt |
+| `--use-env <KEY>` | Import a specific env key from the nanosb startup env pool (repeatable) |
+| `--run-as-root` | Run agent commands as root inside the guest VM |
+
+> The `--run-as-root` flag is the same one available on `nanosb run`. By default the agent runs as a non-root user (some agents refuse to start as root). Pass `--run-as-root` only when a workflow needs root in the guest — most commonly system-level package installs on the Windows FUSE workspace path.
 
 ### Agent & Environment
 

--- a/content/docs/getting-started/installation.md
+++ b/content/docs/getting-started/installation.md
@@ -4,25 +4,25 @@ description: "Install the nanosb CLI on your system"
 order: 1
 ---
 
-## Install via Shell Script
+## Install on macOS or Linux
 
-The fastest way to install the `nanosb` CLI is with the official installer script:
+The fastest way to install the `nanosb` CLI on macOS or Linux is with the official shell installer:
 
 ```bash
 curl -fsSL https://github.com/nanosandboxai/cli/releases/latest/download/install.sh | bash
 ```
 
-The script automatically detects your platform, downloads the correct binary, and places it on your `PATH`.
+The script detects your platform, downloads the correct binary, and places it on your `PATH`.
 
 ### What Gets Installed
 
 The installer sets up three components:
 
-| Component    | Description                                              |
-| ------------ | -------------------------------------------------------- |
-| **nanosb**   | The CLI binary for managing and running microVM sandboxes |
-| **libkrun**  | Lightweight VMM library that powers the microVM runtime  |
-| **gvproxy**  | User-space networking proxy for sandbox network access    |
+| Component    | Description                                               |
+| ------------ | --------------------------------------------------------- |
+| **nanosb**   | CLI binary for creating and running microVM sandboxes     |
+| **libkrun**  | Lightweight VMM library used by the runtime               |
+| **gvproxy**  | User-space networking proxy for bridge networking (Linux) |
 
 By default, binaries are installed to `~/.nanosb/bin`. You can override this with the `INSTALL_DIR` environment variable:
 
@@ -38,6 +38,25 @@ After installing, confirm the CLI is working:
 nanosb --version
 ```
 
+## Install on Windows
+
+Use the PowerShell installer:
+
+```powershell
+irm https://raw.githubusercontent.com/nanosandboxai/cli/v0.2.0/scripts/install.ps1 | iex
+```
+
+On a fresh machine, the installer can enable Hyper-V and WHPX automatically. If Windows needs a reboot, the installer prompts you and then resumes after login.
+
+After installation, verify runtime dependencies:
+
+```terminal
+> nanosb doctor
+  [ok] WHPX: Windows Hypervisor Platform available
+  [ok] libkrunfw.dll: found at C:\Users\you\.nanosandbox\libs\libkrunfw.dll
+  [ok] vsock_proxy: found
+```
+
 ## Platform Support
 
-The CLI currently supports **macOS on Apple Silicon (arm64)**. Linux support via KVM is in development. See [System Requirements](./system-requirements.md) for full platform details.
+Nanosandbox supports macOS, Windows 11, and Linux hosts (Linux remains in active development). See [System Requirements](./system-requirements.md) for full platform details.

--- a/content/docs/getting-started/installation.md
+++ b/content/docs/getting-started/installation.md
@@ -46,18 +46,21 @@ Use the PowerShell installer. Run PowerShell as Administrator on a fresh machine
 irm https://github.com/nanosandboxai/cli/releases/latest/download/install.ps1 | iex
 ```
 
+> **Heads up: run elevated.** If you launch the installer from a non-elevated terminal **and** your user is not in the local `Hyper-V Administrators` group, the installer prints a clear warning explaining what will be skipped (feature enables, Defender exclusions) and asks before continuing. Sandbox creation will then fail with `access denied` from the Host Compute Service until you elevate or join the group.
+
 The installer:
 
-1. Enables Hyper-V, Windows Hypervisor Platform, Windows Subsystem for Linux, and Virtual Machine Platform if any are missing.
-2. Installs the Microsoft Visual C++ Redistributable inline (no reboot).
-3. If any Windows feature required a restart, prompts you once. After login the installer resumes automatically via a one-shot RunOnce entry.
-4. Downloads `nanosb.exe` to `%USERPROFILE%\.nanosandbox\`.
-5. Installs the four runtime files into `%USERPROFILE%\.nanosandbox\libs\`:
+1. Checks whether you are running as Administrator or are a member of `Hyper-V Administrators`. If neither, it asks before continuing.
+2. Enables Hyper-V, Windows Hypervisor Platform, Windows Subsystem for Linux, and Virtual Machine Platform if any are missing.
+3. Installs the Microsoft Visual C++ Redistributable inline (no reboot).
+4. If any Windows feature required a restart, prompts you once. After login the installer resumes automatically via a one-shot RunOnce entry.
+5. Downloads `nanosb.exe` to `%USERPROFILE%\.nanosandbox\`.
+6. Installs the four runtime files into `%USERPROFILE%\.nanosandbox\libs\`:
    - `libkrunfw.dll` — guest kernel firmware
    - `busybox` — Linux ELF used as guest init shell
    - `vsock_proxy` — Linux ELF that bridges HvSocket and AF_VSOCK
    - `fuse_mount` — Linux ELF that mounts the rootfs and workspace over FUSE
-6. Adds the install directory to your user `PATH`.
+7. Adds the install directory to your user `PATH`.
 
 After installation, verify everything is in place:
 
@@ -67,6 +70,7 @@ After installation, verify everything is in place:
 Checking runtime prerequisites...
 
   [✓] HCS Service: running (vmcompute)
+  [✓] Hyper-V Access: user has Hyper-V access (admin or Hyper-V Administrators)
   [✓] WSL Kernel: found
   [✓] libkrunfw.dll: found
   [✓] busybox: found
@@ -75,9 +79,15 @@ Checking runtime prerequisites...
   [✓] Disk: SSD detected
   [✓] Memory: sufficient RAM available
 
-8 checks passed, 0 errors, 0 warnings
+9 checks passed, 0 errors, 0 warnings
 
 Ready to run sandboxes.
+```
+
+If `nanosb doctor` reports `[✗] Hyper-V Access`, run this once in an elevated PowerShell, then log out and back in:
+
+```powershell
+Add-LocalGroupMember -Group 'Hyper-V Administrators' -Member $env:USERNAME
 ```
 
 If `nanosb doctor` reports a missing dependency, re-run the installer or follow the fix hint it prints.

--- a/content/docs/getting-started/installation.md
+++ b/content/docs/getting-started/installation.md
@@ -40,22 +40,47 @@ nanosb --version
 
 ## Install on Windows
 
-Use the PowerShell installer:
+Use the PowerShell installer. Run PowerShell as Administrator on a fresh machine so the installer can enable Windows features in one step:
 
 ```powershell
-irm https://raw.githubusercontent.com/nanosandboxai/cli/v0.2.0/scripts/install.ps1 | iex
+irm https://github.com/nanosandboxai/cli/releases/latest/download/install.ps1 | iex
 ```
 
-On a fresh machine, the installer can enable Hyper-V and WHPX automatically. If Windows needs a reboot, the installer prompts you and then resumes after login.
+The installer:
 
-After installation, verify runtime dependencies:
+1. Enables Hyper-V, Windows Hypervisor Platform, Windows Subsystem for Linux, and Virtual Machine Platform if any are missing.
+2. Installs the Microsoft Visual C++ Redistributable inline (no reboot).
+3. If any Windows feature required a restart, prompts you once. After login the installer resumes automatically via a one-shot RunOnce entry.
+4. Downloads `nanosb.exe` to `%USERPROFILE%\.nanosandbox\`.
+5. Installs the four runtime files into `%USERPROFILE%\.nanosandbox\libs\`:
+   - `libkrunfw.dll` — guest kernel firmware
+   - `busybox` — Linux ELF used as guest init shell
+   - `vsock_proxy` — Linux ELF that bridges HvSocket and AF_VSOCK
+   - `fuse_mount` — Linux ELF that mounts the rootfs and workspace over FUSE
+6. Adds the install directory to your user `PATH`.
 
-```terminal
+After installation, verify everything is in place:
+
+```powershell
 > nanosb doctor
-  [ok] WHPX: Windows Hypervisor Platform available
-  [ok] libkrunfw.dll: found at C:\Users\you\.nanosandbox\libs\libkrunfw.dll
-  [ok] vsock_proxy: found
+
+Checking runtime prerequisites...
+
+  [✓] HCS Service: running (vmcompute)
+  [✓] WSL Kernel: found
+  [✓] libkrunfw.dll: found
+  [✓] busybox: found
+  [✓] vsock_proxy: found
+  [✓] fuse_mount: found
+  [✓] Disk: SSD detected
+  [✓] Memory: sufficient RAM available
+
+8 checks passed, 0 errors, 0 warnings
+
+Ready to run sandboxes.
 ```
+
+If `nanosb doctor` reports a missing dependency, re-run the installer or follow the fix hint it prints.
 
 ## Platform Support
 

--- a/content/docs/getting-started/system-requirements.md
+++ b/content/docs/getting-started/system-requirements.md
@@ -69,10 +69,20 @@ The installer can enable missing Windows features automatically and will prompt 
 
 ### Runtime Dependencies
 
-- `libkrunfw.dll` present in `%USERPROFILE%\\.nanosandbox\\libs\\`
-- `vsock_proxy` available in the same runtime folder
+The Windows installer places four files in `%USERPROFILE%\.nanosandbox\libs\`. They run inside the Linux guest, so they have no `.exe` extension:
 
-These dependencies are installed automatically by the [PowerShell installer](./installation.md).
+| File | Role |
+| --- | --- |
+| `libkrunfw.dll` | Guest Linux kernel firmware loaded by libkrun |
+| `busybox` | Static Linux ELF used as the guest init shell |
+| `vsock_proxy` | Static Linux ELF that bridges HvSocket and AF_VSOCK |
+| `fuse_mount` | Static Linux ELF that mounts the rootfs and workspace over FUSE-on-vsock |
+
+These dependencies are installed automatically by the [PowerShell installer](./installation.md). You can verify them at any time with:
+
+```powershell
+nanosb doctor
+```
 
 ## Environment Variables
 

--- a/content/docs/getting-started/system-requirements.md
+++ b/content/docs/getting-started/system-requirements.md
@@ -9,6 +9,7 @@ order: 3
 | Platform                    | Hypervisor        | Status             |
 | --------------------------- | ----------------- | ------------------ |
 | macOS Apple Silicon (arm64) | HVF               | **Stable**         |
+| Windows 11 (x86_64)         | WHPX              | **Experimental**   |
 | Linux (x86_64 / arm64)     | KVM               | **In Development** |
 
 ## macOS Requirements
@@ -52,6 +53,26 @@ Linux support targets KVM-based virtualization. The following will be required o
 - libkrun built for your distribution
 
 Linux binaries are not yet published. Check the [releases page](https://github.com/nanosandboxai/cli/releases) for updates.
+
+## Windows Requirements
+
+### Hardware
+
+- 64-bit CPU with virtualization support enabled in BIOS/UEFI
+
+### Software
+
+- Windows 11 (22H2 or later)
+- Hyper-V and Windows Hypervisor Platform (WHPX)
+
+The installer can enable missing Windows features automatically and will prompt for a reboot if needed.
+
+### Runtime Dependencies
+
+- `libkrunfw.dll` present in `%USERPROFILE%\\.nanosandbox\\libs\\`
+- `vsock_proxy` available in the same runtime folder
+
+These dependencies are installed automatically by the [PowerShell installer](./installation.md).
 
 ## Environment Variables
 

--- a/content/docs/troubleshooting/common-errors.md
+++ b/content/docs/troubleshooting/common-errors.md
@@ -82,7 +82,14 @@ Error: failed to create sandbox
 
 2. **Windows virtualization features are disabled.** Enable Hyper-V and WHPX in "Turn Windows features on or off", then reboot.
 
-3. **Missing runtime files.** Ensure these four files exist (they have no `.exe` extension because they run inside the Linux guest):
+3. **User is not allowed to talk to the Host Compute Service.** If `nanosb doctor` reports `[✗] Hyper-V Access`, add yourself to the `Hyper-V Administrators` group (or run nanosb from an elevated terminal):
+   ```powershell
+   # Elevated PowerShell:
+   Add-LocalGroupMember -Group 'Hyper-V Administrators' -Member $env:USERNAME
+   # Log out and back in for the group to take effect.
+   ```
+
+5. **Missing runtime files.** Ensure these four files exist (they have no `.exe` extension because they run inside the Linux guest):
    - `%USERPROFILE%\.nanosandbox\libs\libkrunfw.dll`
    - `%USERPROFILE%\.nanosandbox\libs\busybox`
    - `%USERPROFILE%\.nanosandbox\libs\vsock_proxy`
@@ -93,11 +100,11 @@ Error: failed to create sandbox
    irm https://github.com/nanosandboxai/cli/releases/latest/download/install.ps1 | iex
    ```
 
-4. **Quick check with the doctor command.**
+6. **Quick check with the doctor command.**
    ```powershell
    nanosb doctor
    ```
-   It reports each runtime file individually and prints the exact command to reinstall.
+   It reports each runtime file (and Hyper-V Access) individually and prints the exact command to reinstall.
 
 ## Timeout Errors
 

--- a/content/docs/troubleshooting/common-errors.md
+++ b/content/docs/troubleshooting/common-errors.md
@@ -82,14 +82,22 @@ Error: failed to create sandbox
 
 2. **Windows virtualization features are disabled.** Enable Hyper-V and WHPX in "Turn Windows features on or off", then reboot.
 
-3. **Missing runtime files.** Ensure these files exist:
-   - `%USERPROFILE%\\.nanosandbox\\libs\\libkrunfw.dll`
-   - `%USERPROFILE%\\.nanosandbox\\libs\\vsock_proxy.exe`
+3. **Missing runtime files.** Ensure these four files exist (they have no `.exe` extension because they run inside the Linux guest):
+   - `%USERPROFILE%\.nanosandbox\libs\libkrunfw.dll`
+   - `%USERPROFILE%\.nanosandbox\libs\busybox`
+   - `%USERPROFILE%\.nanosandbox\libs\vsock_proxy`
+   - `%USERPROFILE%\.nanosandbox\libs\fuse_mount`
 
-   Re-run the installer if they are missing:
+   Re-run the installer if any of them is missing:
    ```powershell
-   irm https://raw.githubusercontent.com/nanosandboxai/cli/v0.2.0/scripts/install.ps1 | iex
+   irm https://github.com/nanosandboxai/cli/releases/latest/download/install.ps1 | iex
    ```
+
+4. **Quick check with the doctor command.**
+   ```powershell
+   nanosb doctor
+   ```
+   It reports each runtime file individually and prints the exact command to reinstall.
 
 ## Timeout Errors
 

--- a/content/docs/troubleshooting/common-errors.md
+++ b/content/docs/troubleshooting/common-errors.md
@@ -65,6 +65,32 @@ Error: failed to create sandbox
    nanosb run --memory 2048 claude
    ```
 
+## Windows Hypervisor Errors
+
+**Error:**
+```
+Error: failed to create sandbox
+  Caused by: WHPX not available
+```
+
+**Causes and fixes:**
+
+1. **Hypervisor launch is disabled.** Enable it and reboot:
+   ```powershell
+   bcdedit /set hypervisorlaunchtype auto
+   ```
+
+2. **Windows virtualization features are disabled.** Enable Hyper-V and WHPX in "Turn Windows features on or off", then reboot.
+
+3. **Missing runtime files.** Ensure these files exist:
+   - `%USERPROFILE%\\.nanosandbox\\libs\\libkrunfw.dll`
+   - `%USERPROFILE%\\.nanosandbox\\libs\\vsock_proxy.exe`
+
+   Re-run the installer if they are missing:
+   ```powershell
+   irm https://raw.githubusercontent.com/nanosandboxai/cli/v0.2.0/scripts/install.ps1 | iex
+   ```
+
 ## Timeout Errors
 
 **Error:**
@@ -205,3 +231,7 @@ Error: failed to mount /workspace
    ```
 
 3. **Symlink issues.** If paths aren't resolving, check for symlinks in the project path.
+
+4. **Windows path edge cases.** On Windows, very long paths and mixed case can still cause confusing behavior in older tools. Use a shorter workspace path when possible and keep path casing consistent.
+
+   The previous "directory not empty" cleanup issue in common package-manager workflows is fixed in current builds.

--- a/content/docs/troubleshooting/common-errors.md
+++ b/content/docs/troubleshooting/common-errors.md
@@ -155,6 +155,20 @@ ls -la ./project
 chmod 755 ./project
 ```
 
+**Windows (FUSE workspace on NTFS):** NTFS does not track POSIX ownership the same way. If a guest tool needs to write outside the user-owned tree (system package installs, build scripts that touch `/etc`, etc.), retry with `--run-as-root`:
+
+```powershell
+nanosb run --run-as-root <image> "<command>"
+```
+
+Or inside the TUI:
+
+```
+/add <agent> --run-as-root
+```
+
+Keep the default off for normal development; some agents refuse to start as root.
+
 ## Network Errors
 
 **Error:**

--- a/content/docs/troubleshooting/doctor-command.md
+++ b/content/docs/troubleshooting/doctor-command.md
@@ -12,159 +12,73 @@ The `nanosb doctor` command checks that all runtime prerequisites are installed 
 nanosb doctor
 ```
 
+The command prints a colored checklist. Each line uses one of three markers:
+
+| Marker | Meaning |
+| --- | --- |
+| `[✓]` | Check passed |
+| `[!]` | Warning — not fatal, but worth knowing |
+| `[✗]` | Check failed — fix before running a sandbox |
+
+If anything fails, `nanosb doctor` exits with a non-zero status so it can be wired into CI.
+
 ## What It Checks
 
-### Platform Detection
+The exact checks depend on the host OS.
 
-Identifies the host OS, architecture, and available hypervisor.
+### macOS
 
-```
-[ok] Platform: macOS (Apple Silicon)
-[ok] Architecture: arm64
-```
+| Check | What it verifies |
+| --- | --- |
+| `Architecture` | Apple Silicon (aarch64) |
+| `libkrunfw Kernel Firmware` | `libkrunfw.5.dylib` is reachable from `~/.nanosandbox/libs`, Homebrew prefix, or `/usr/local/lib` |
+| `Hypervisor.framework` | macOS HVF is available |
+| `gvproxy` | Optional bridge-networking helper |
 
-On Linux, it checks the kernel version (requires 5.10+):
-
-```
-[ok] Platform: Linux
-[ok] Architecture: x86_64
-[ok] Kernel: 6.5.0-generic (>= 5.10 required)
-```
-
-### Hypervisor Availability
-
-Verifies the platform hypervisor is accessible.
-
-**macOS (HVF):**
-```
-[ok] Hypervisor: HVF available
-```
-
-If HVF is not available, the output indicates possible causes:
-```
-[FAIL] Hypervisor: HVF not available
-  -> Ensure you are running macOS 12.0 or later
-  -> Check that SIP (System Integrity Protection) is enabled
-```
-
-**Linux (KVM):**
-```
-[ok] Hypervisor: KVM available (/dev/kvm accessible)
-```
+Sample failure with fix hint:
 
 ```
-[FAIL] Hypervisor: /dev/kvm not accessible
-  -> Run: sudo usermod -aG kvm $USER
-  -> Then log out and back in
+  [✗] libkrunfw Kernel Firmware: libkrunfw.5.dylib not found in ~/.nanosandbox/libs/, /opt/homebrew/lib, or /usr/local/lib
+      Fix: brew install libkrunfw
 ```
 
-```
-[FAIL] Hypervisor: KVM module not loaded
-  -> Run: sudo modprobe kvm_intel   (Intel CPUs)
-  -> Run: sudo modprobe kvm_amd     (AMD CPUs)
-```
+### Linux
 
-**Windows (WHPX):**
-```
-[ok] Hypervisor: WHPX available
-```
+| Check | What it verifies |
+| --- | --- |
+| `libkrunfw Kernel Firmware` | `libkrunfw.so.5` is reachable via the dynamic linker |
+| `KVM Device` | `/dev/kvm` is accessible by the current user |
+| `gvproxy` | Optional bridge-networking helper |
 
-```
-[FAIL] Hypervisor: WHPX not available
-  -> Enable Hyper-V and Windows Hypervisor Platform
-  -> Run: bcdedit /set hypervisorlaunchtype auto
-  -> Reboot Windows
-```
-
-### libkrun
-
-Checks that libkrun is installed and the version is compatible.
+Sample failure with fix hint:
 
 ```
-[ok] libkrun: v1.9.2 (>= 1.7.0 required)
+  [✗] KVM Device: /dev/kvm not accessible
+      Fix: sudo usermod -aG kvm $USER && log out and back in
 ```
 
-```
-[FAIL] libkrun: not found
-  -> macOS:  brew install libkrun
-  -> Linux:  sudo apt install libkrun-dev
-  -> Or build from source: https://github.com/containers/libkrun
-```
+### Windows
+
+| Check | What it verifies |
+| --- | --- |
+| `HCS Service` | `vmcompute` service is running (depends on Hyper-V) |
+| `WSL Kernel` | `C:\Program Files\WSL\tools\kernel` is present |
+| `libkrunfw.dll` | Guest kernel firmware in `%USERPROFILE%\.nanosandbox\libs\` |
+| `busybox` | Static Linux ELF used as the guest init shell |
+| `vsock_proxy` | Static Linux ELF that bridges HvSocket and AF_VSOCK |
+| `fuse_mount` | Static Linux ELF that mounts the rootfs and workspace over FUSE |
+| `Disk` | SSD detected (warning only on HDD/unknown) |
+| `Memory` | At least a few GB of free RAM |
+
+Sample failure with fix hint:
 
 ```
-[WARN] libkrun: v1.5.0 (>= 1.7.0 required, some features may not work)
-  -> Upgrade: brew upgrade libkrun
+  [✗] fuse_mount: fuse_mount not found. Required for Windows VM boot path.
+      Fix: Install runtime deps:
+             irm https://github.com/nanosandboxai/install-deps/releases/latest/download/install.ps1 | iex
 ```
 
-### libkrunfw
-
-Checks the firmware library that bundles the guest kernel and initrd.
-
-```
-[ok] libkrunfw: v4.2.0
-```
-
-```
-[FAIL] libkrunfw: not found
-  -> macOS:  brew install libkrunfw
-  -> Linux:  sudo apt install libkrunfw
-```
-
-### Windows Runtime Files
-
-On Windows, `nanosb doctor` also checks the runtime files used by WHPX sessions:
-
-```
-[ok] libkrunfw.dll: found at C:\Users\you\.nanosandbox\libs\libkrunfw.dll
-[ok] vsock_proxy: found at C:\Users\you\.nanosandbox\libs\vsock_proxy.exe
-```
-
-```
-[FAIL] libkrunfw.dll: not found
-  -> Re-run installer: irm https://raw.githubusercontent.com/nanosandboxai/cli/v0.2.0/scripts/install.ps1 | iex
-```
-
-### Codesigning (macOS only)
-
-Verifies the nanosb binary has the hypervisor entitlement.
-
-```
-[ok] Codesigning: valid entitlements (com.apple.security.hypervisor)
-```
-
-```
-[FAIL] Codesigning: missing com.apple.security.hypervisor entitlement
-  -> Run: codesign --entitlements entitlements.plist --force -s - $(which nanosb)
-  -> See: /docs/getting-started/system-requirements
-```
-
-### gvproxy (optional)
-
-Checks for gvproxy, needed for bridge networking mode. This is a warning, not a failure, since TSI mode works without it.
-
-```
-[ok] gvproxy: found at /opt/homebrew/bin/gvproxy (v0.7.3)
-```
-
-```
-[WARN] gvproxy: not found
-  -> Bridge networking will not work
-  -> TSI mode (default) does not require gvproxy
-  -> Install: brew install gvproxy  (macOS)
-  -> Install: sudo apt install gvproxy  (Linux)
-```
-
-### Image Cache
-
-Checks the cache directory is accessible and reports usage.
-
-```
-[ok] Cache: /Users/you/.nanosandbox/cache (1.2 GB, 47 blobs)
-```
-
-```
-[WARN] Cache: directory not found, will be created on first pull
-```
+> The four Linux ELFs (`busybox`, `vsock_proxy`, `fuse_mount`, and the kernel firmware `libkrunfw.dll`) are installed automatically by the Windows installer. They live in `%USERPROFILE%\.nanosandbox\libs\` and have no `.exe` extension — they run inside the Linux guest.
 
 ## Full Output Example
 
@@ -173,61 +87,56 @@ Checks the cache directory is accessible and reports usage.
 ```bash
 $ nanosb doctor
 
-Nanosandbox Doctor
-==================
+Checking runtime prerequisites...
 
-[ok] Platform: macOS (Apple Silicon)
-[ok] Architecture: arm64
-[ok] Hypervisor: HVF available
-[ok] libkrun: v1.9.2
-[ok] libkrunfw: v4.2.0
-[ok] Codesigning: valid entitlements
-[ok] gvproxy: found at /opt/homebrew/bin/gvproxy (v0.7.3)
-[ok] Cache: /Users/you/.nanosandbox/cache (1.2 GB, 47 blobs)
+  [✓] Architecture: Apple Silicon (aarch64)
+  [✓] libkrunfw Kernel Firmware: found (libkrunfw.5.dylib)
+  [✓] Hypervisor.framework: available
+  [✓] gvproxy: available (full outbound networking)
 
-All checks passed. Nanosandbox is ready to use.
+4 checks passed, 0 errors, 0 warnings
+
+Ready to run sandboxes.
+  Logs: /Users/you/.nanosandbox/logs
 ```
 
-### Linux (some issues)
+### Linux (one failure)
 
 ```bash
 $ nanosb doctor
 
-Nanosandbox Doctor
-==================
+Checking runtime prerequisites...
 
-[ok] Platform: Linux
-[ok] Architecture: x86_64
-[ok] Kernel: 6.5.0-generic
-[FAIL] Hypervisor: /dev/kvm not accessible
-  -> Run: sudo usermod -aG kvm $USER
-  -> Then log out and back in
-[ok] libkrun: v1.9.0
-[ok] libkrunfw: v4.2.0
-[WARN] gvproxy: not found
-  -> Bridge networking will not work
-  -> Install: sudo apt install gvproxy
-[ok] Cache: /home/you/.nanosandbox/cache (830 MB, 31 blobs)
+  [✓] libkrunfw Kernel Firmware: found (libkrunfw.so.5)
+  [✗] KVM Device: /dev/kvm not accessible
+      Fix: sudo usermod -aG kvm $USER && log out and back in
+  [✓] gvproxy: available (full outbound networking)
 
-1 check failed, 1 warning. Fix the issues above and run 'nanosb doctor' again.
+2 checks passed, 1 errors, 0 warnings
+
+Cannot run sandboxes. Fix the errors above.
 ```
 
-### Windows (WHPX)
+### Windows (all passing)
 
 ```powershell
 > nanosb doctor
 
-Nanosandbox Doctor
-==================
+Checking runtime prerequisites...
 
-[ok] Platform: Windows
-[ok] Architecture: x86_64
-[ok] Hypervisor: WHPX available
-[ok] libkrunfw.dll: found at C:\Users\you\.nanosandbox\libs\libkrunfw.dll
-[ok] vsock_proxy: found at C:\Users\you\.nanosandbox\libs\vsock_proxy.exe
-[ok] Cache: C:\Users\you\.nanosandbox\cache (420 MB, 18 blobs)
+  [✓] HCS Service: running (vmcompute)
+  [✓] WSL Kernel: found
+  [✓] libkrunfw.dll: found
+  [✓] busybox: found
+  [✓] vsock_proxy: found
+  [✓] fuse_mount: found
+  [✓] Disk: SSD detected
+  [✓] Memory: sufficient RAM available
 
-All checks passed. Nanosandbox is ready to use.
+8 checks passed, 0 errors, 0 warnings
+
+Ready to run sandboxes.
+  Logs: C:\Users\you\.nanosandbox\logs
 ```
 
 ## Fixing Common Issues
@@ -311,17 +220,28 @@ nanosb doctor --format json
 
 ```json
 {
-  "checks": [
-    { "name": "platform", "status": "ok", "detail": "macOS (Apple Silicon)" },
-    { "name": "hypervisor", "status": "ok", "detail": "HVF available" },
-    { "name": "libkrun", "status": "ok", "detail": "v1.9.2" },
-    { "name": "libkrunfw", "status": "ok", "detail": "v4.2.0" },
-    { "name": "codesigning", "status": "ok", "detail": "valid entitlements" },
-    { "name": "gvproxy", "status": "ok", "detail": "/opt/homebrew/bin/gvproxy (v0.7.3)" },
-    { "name": "cache", "status": "ok", "detail": "1.2 GB, 47 blobs" }
+  "ok": true,
+  "platform": "windows",
+  "arch": "x86_64",
+  "errors": [],
+  "warnings": []
+}
+```
+
+When checks fail, each entry in `errors` includes a `check` name, a `message`, and an optional `fix_hint`:
+
+```json
+{
+  "ok": false,
+  "platform": "windows",
+  "arch": "x86_64",
+  "errors": [
+    {
+      "check": "fuse_mount",
+      "message": "fuse_mount not found. Required for Windows VM boot path.",
+      "fix_hint": "Install runtime deps:\n irm https://github.com/nanosandboxai/install-deps/releases/latest/download/install.ps1 | iex"
+    }
   ],
-  "passed": 7,
-  "failed": 0,
-  "warnings": 0
+  "warnings": []
 }
 ```

--- a/content/docs/troubleshooting/doctor-command.md
+++ b/content/docs/troubleshooting/doctor-command.md
@@ -62,6 +62,7 @@ Sample failure with fix hint:
 | Check | What it verifies |
 | --- | --- |
 | `HCS Service` | `vmcompute` service is running (depends on Hyper-V) |
+| `Hyper-V Access` | The current user is in the `Hyper-V Administrators` group or running elevated |
 | `WSL Kernel` | `C:\Program Files\WSL\tools\kernel` is present |
 | `libkrunfw.dll` | Guest kernel firmware in `%USERPROFILE%\.nanosandbox\libs\` |
 | `busybox` | Static Linux ELF used as the guest init shell |
@@ -69,6 +70,14 @@ Sample failure with fix hint:
 | `fuse_mount` | Static Linux ELF that mounts the rootfs and workspace over FUSE |
 | `Disk` | SSD detected (warning only on HDD/unknown) |
 | `Memory` | At least a few GB of free RAM |
+
+> **About `Hyper-V Access`.** The Host Compute Service (HCS) APIs that boot the microVM require the caller to be a member of the local `Hyper-V Administrators` group or to be running elevated as `Administrator`. Without either, sandbox creation fails with confusing access-denied errors from `vmcompute`. The fastest fix is to add the user to the group once:
+>
+> ```powershell
+> # Run in an elevated PowerShell:
+> Add-LocalGroupMember -Group 'Hyper-V Administrators' -Member $env:USERNAME
+> # Then log out and back in for the group to take effect.
+> ```
 
 Sample failure with fix hint:
 
@@ -125,6 +134,7 @@ Cannot run sandboxes. Fix the errors above.
 Checking runtime prerequisites...
 
   [✓] HCS Service: running (vmcompute)
+  [✓] Hyper-V Access: user has Hyper-V access (admin or Hyper-V Administrators)
   [✓] WSL Kernel: found
   [✓] libkrunfw.dll: found
   [✓] busybox: found
@@ -133,7 +143,7 @@ Checking runtime prerequisites...
   [✓] Disk: SSD detected
   [✓] Memory: sufficient RAM available
 
-8 checks passed, 0 errors, 0 warnings
+9 checks passed, 0 errors, 0 warnings
 
 Ready to run sandboxes.
   Logs: C:\Users\you\.nanosandbox\logs

--- a/content/docs/troubleshooting/doctor-command.md
+++ b/content/docs/troubleshooting/doctor-command.md
@@ -64,6 +64,18 @@ If HVF is not available, the output indicates possible causes:
   -> Run: sudo modprobe kvm_amd     (AMD CPUs)
 ```
 
+**Windows (WHPX):**
+```
+[ok] Hypervisor: WHPX available
+```
+
+```
+[FAIL] Hypervisor: WHPX not available
+  -> Enable Hyper-V and Windows Hypervisor Platform
+  -> Run: bcdedit /set hypervisorlaunchtype auto
+  -> Reboot Windows
+```
+
 ### libkrun
 
 Checks that libkrun is installed and the version is compatible.
@@ -96,6 +108,20 @@ Checks the firmware library that bundles the guest kernel and initrd.
 [FAIL] libkrunfw: not found
   -> macOS:  brew install libkrunfw
   -> Linux:  sudo apt install libkrunfw
+```
+
+### Windows Runtime Files
+
+On Windows, `nanosb doctor` also checks the runtime files used by WHPX sessions:
+
+```
+[ok] libkrunfw.dll: found at C:\Users\you\.nanosandbox\libs\libkrunfw.dll
+[ok] vsock_proxy: found at C:\Users\you\.nanosandbox\libs\vsock_proxy.exe
+```
+
+```
+[FAIL] libkrunfw.dll: not found
+  -> Re-run installer: irm https://raw.githubusercontent.com/nanosandboxai/cli/v0.2.0/scripts/install.ps1 | iex
 ```
 
 ### Codesigning (macOS only)
@@ -184,6 +210,24 @@ Nanosandbox Doctor
 [ok] Cache: /home/you/.nanosandbox/cache (830 MB, 31 blobs)
 
 1 check failed, 1 warning. Fix the issues above and run 'nanosb doctor' again.
+```
+
+### Windows (WHPX)
+
+```powershell
+> nanosb doctor
+
+Nanosandbox Doctor
+==================
+
+[ok] Platform: Windows
+[ok] Architecture: x86_64
+[ok] Hypervisor: WHPX available
+[ok] libkrunfw.dll: found at C:\Users\you\.nanosandbox\libs\libkrunfw.dll
+[ok] vsock_proxy: found at C:\Users\you\.nanosandbox\libs\vsock_proxy.exe
+[ok] Cache: C:\Users\you\.nanosandbox\cache (420 MB, 18 blobs)
+
+All checks passed. Nanosandbox is ready to use.
 ```
 
 ## Fixing Common Issues


### PR DESCRIPTION
## What changed\n- add Windows host support details to getting started docs\n  - system-requirements.md: Windows 11 + WHPX row and requirements section\n  - installation.md: Windows PowerShell install path and doctor verification example\n- expand troubleshooting with Windows-focused guidance\n  - hypervisor availability fixes\n  - runtime file checks and remediation\n  - workspace mount/path edge-case notes\n- add new architecture section\n  - content/docs/architecture/_meta.json\n  - content/docs/architecture/overview.md\n  - cross-platform architecture flow and Windows gap positioning at a readable, high level\n\n## Why\n- align docs with current Windows runtime state and reduce onboarding confusion\n- keep article messaging high-level while placing operational details in docs\n\n## Related issues\n- No matching issue found in this repo for this Windows docs expansion.